### PR TITLE
Dispose image URL validation requests and responses

### DIFF
--- a/src/Jellyfin.Plugin.Kinopoisk.Tests/RemoteImageUrlSanitizerTests.cs
+++ b/src/Jellyfin.Plugin.Kinopoisk.Tests/RemoteImageUrlSanitizerTests.cs
@@ -1,0 +1,76 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Jellyfin.Plugin.Kinopoisk.Tests
+{
+    public class RemoteImageUrlSanitizerTests
+    {
+        [Fact]
+        public async Task SanitizeRemoteImageUrlDisposesRequestAndResponse()
+        {
+            using var handler = new TrackingHandler();
+            using var httpClient = new HttpClient(handler);
+
+            var sanitizer = new RemoteImageUrlSanitizer(httpClient);
+
+            var result = await sanitizer.SanitizeRemoteImageUrl(
+                "https://example.com/image.jpg");
+
+            Assert.Equal("https://example.com/image.jpg", result);
+            Assert.True(handler.RequestContent.IsDisposed);
+            Assert.True(handler.ResponseContent.IsDisposed);
+        }
+
+        private sealed class TrackingHandler : HttpMessageHandler
+        {
+            public TrackingContent RequestContent { get; } = new TrackingContent();
+
+            public TrackingContent ResponseContent { get; } = new TrackingContent();
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                request.Content = RequestContent;
+
+                return Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = ResponseContent
+                    });
+            }
+        }
+
+        private sealed class TrackingContent : HttpContent
+        {
+            public bool IsDisposed { get; private set; }
+
+            protected override Task SerializeToStreamAsync(
+                Stream stream,
+                TransportContext context)
+            {
+                return Task.CompletedTask;
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = 0;
+                return true;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    IsDisposed = true;
+                }
+
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.Kinopoisk/RemoteImageUrlSanitizer.cs
+++ b/src/Jellyfin.Plugin.Kinopoisk/RemoteImageUrlSanitizer.cs
@@ -21,8 +21,10 @@ namespace Jellyfin.Plugin.Kinopoisk
             var currentUrl = url;
             while (!currentUrl.Contains("no-poster"))
             {
-                var response = await _httpClient.SendAsync(
-                    new HttpRequestMessage(HttpMethod.Get, currentUrl), HttpCompletionOption.ResponseHeadersRead);
+                using var request = new HttpRequestMessage(HttpMethod.Get, currentUrl);
+                using var response = await _httpClient.SendAsync(
+                    request,
+                    HttpCompletionOption.ResponseHeadersRead);
 
                 if ((int)response.StatusCode <= 299)
                     return currentUrl;


### PR DESCRIPTION
## Summary

Dispose `HttpRequestMessage` and `HttpResponseMessage` instances created while validating remote image URLs.

This prevents connections from remaining in `CLOSE_WAIT` during metadata and image refreshes.

## Changes

* Dispose each image validation request.
* Dispose each image validation response.
* Add a regression test covering request and response disposal.

## Testing

* All 13 automated tests pass.
* Tested with Jellyfin 10.11.11.
* Performed a full metadata and image refresh for approximately 167 movies.
* Tested newly added movies and repeated metadata replacement.
* `ESTABLISHED` connections closed normally.
* `CLOSE_WAIT` remained at or near zero.
* No `RemoteImageUrlSanitizer` HTTP timeouts occurred.
