### PR TITLE
Skip staff entries without names

### DIFF
--- a/src/Jellyfin.Plugin.Kinopoisk.Tests/ApiModelExtensionsTests.cs
+++ b/src/Jellyfin.Plugin.Kinopoisk.Tests/ApiModelExtensionsTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using KinopoiskUnofficialInfo.ApiClient;
+using Xunit;
+
+namespace Jellyfin.Plugin.Kinopoisk.Tests
+{
+    public class ApiModelExtensionsTests
+    {
+        [Fact]
+        public void ToPersonInfosShouldSkipPersonsWithoutNames()
+        {
+            var staff = new List<StaffResponse>
+            {
+                CreateStaff(1, "Иван Иванов", string.Empty),
+                CreateStaff(2, string.Empty, string.Empty),
+                CreateStaff(3, "   ", "   "),
+                CreateStaff(4, string.Empty, "John Smith")
+            };
+
+            var result = staff.ToPersonInfos().ToArray();
+
+            Assert.Equal(2, result.Length);
+            Assert.Equal("Иван Иванов", result[0].Name);
+            Assert.Equal(1, result[0].SortOrder);
+            Assert.Equal("John Smith", result[1].Name);
+            Assert.Equal(2, result[1].SortOrder);
+        }
+
+        private static StaffResponse CreateStaff(
+            int id,
+            string nameRu,
+            string nameEn)
+        {
+            return new StaffResponse
+            {
+                StaffId = id,
+                NameRu = nameRu,
+                NameEn = nameEn,
+                PosterUrl = string.Empty,
+                ProfessionText = "Актёр",
+                ProfessionKey = StaffResponseProfessionKey.ACTOR
+            };
+        }
+    }
+}

--- a/src/Jellyfin.Plugin.Kinopoisk/ApiModelExtensions.cs
+++ b/src/Jellyfin.Plugin.Kinopoisk/ApiModelExtensions.cs
@@ -257,7 +257,7 @@ namespace Jellyfin.Plugin.Kinopoisk
         public static IEnumerable<PersonInfo> ToPersonInfos(this ICollection<StaffResponse> src)
         {
             var res = src.Select(s => s.ToPersonInfo())
-                .Where(s => s != null)
+                .Where(s => s != null && !string.IsNullOrWhiteSpace(s.Name))
                 .ToArray();
 
             var i = 0;


### PR DESCRIPTION
## Summary

Skip Kinopoisk staff entries that do not contain either a Russian or English name.

Jellyfin rejects `PersonInfo` objects with an empty `Name`, which currently causes metadata refreshes to fail with:

`The value cannot be an empty string. (Parameter 'person.Name')`

## Changes

- Filter out staff entries with empty or whitespace-only names.
- Keep valid Russian and English fallback names.
- Preserve person sort order after filtering.
- Add a regression test.

## Testing

- All 13 automated tests pass.