### PR TITLE
Handle unknown spouse sex values

### DIFF
--- a/src/KinopoiskUnofficialInfo.ApiClient.Tests/BadSpouseSexConverterTests.cs
+++ b/src/KinopoiskUnofficialInfo.ApiClient.Tests/BadSpouseSexConverterTests.cs
@@ -1,0 +1,31 @@
+using Newtonsoft.Json;
+using Xunit;
+
+namespace KinopoiskUnofficialInfo.ApiClient.Tests
+{
+    public class BadSpouseSexConverterTests
+    {
+        [Fact]
+        public void ShouldDeserializeUnknownSpouseSex()
+        {
+            const string json =
+                "{\"personId\":1,\"name\":\"Test\",\"divorced\":false," +
+                "\"divorcedReason\":\"\",\"sex\":\"UNKNOWN\",\"children\":0," +
+                "\"webUrl\":\"\",\"relation\":\"\"}";
+
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = new DeclarationPatcherContractResolver()
+            };
+
+            var result = JsonConvert.DeserializeObject<PersonResponse_spouses>(
+                json,
+                settings);
+
+            Assert.NotNull(result);
+            Assert.Equal(
+                (PersonResponse_spousesSex)(-1),
+                result.Sex);
+        }
+    }
+}

--- a/src/KinopoiskUnofficialInfo.ApiClient/Patchers/BadSpouseSexConverter.cs
+++ b/src/KinopoiskUnofficialInfo.ApiClient/Patchers/BadSpouseSexConverter.cs
@@ -1,0 +1,28 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace KinopoiskUnofficialInfo.ApiClient
+{
+    public class BadSpouseSexConverter : StringEnumConverter
+    {
+        public override bool CanConvert(System.Type objectType)
+            => objectType == typeof(PersonResponse_spousesSex);
+
+        public override object ReadJson(
+            JsonReader reader,
+            System.Type objectType,
+            object existingValue,
+            JsonSerializer serializer)
+        {
+            try
+            {
+                return base.ReadJson(reader, objectType, existingValue, serializer);
+            }
+            catch (Exception)
+            {
+                return (PersonResponse_spousesSex)(-1);
+            }
+        }
+    }
+}

--- a/src/KinopoiskUnofficialInfo.ApiClient/Patchers/DeclarationPatcherContractResolver.cs
+++ b/src/KinopoiskUnofficialInfo.ApiClient/Patchers/DeclarationPatcherContractResolver.cs
@@ -12,6 +12,7 @@ namespace KinopoiskUnofficialInfo.ApiClient
             new BadIntegerConverter(),
             new BadDoubleConverter(),
             new BadProfessionKeyConverter(),
+            new BadSpouseSexConverter(),
             new BadProductionStatusConverter(),
             new BadFilmSearchResponse_filmsTypeConverter(),
         };


### PR DESCRIPTION
## Summary

Handle unexpected `UNKNOWN` values in `PersonResponse.spouses[].sex`.

The Kinopoisk API can return `"UNKNOWN"` even though the generated enum only contains `MALE` and `FEMALE`. This currently causes deserialization of the entire person response to fail.

## Changes

- Add a dedicated converter for `PersonResponse_spousesSex`.
- Preserve normal handling of `MALE` and `FEMALE`.
- Map unsupported values to an internal fallback enum value.
- Add a regression test for `"UNKNOWN"`.

## Testing

- All 13 automated tests pass.