### PR TITLE
Handle Kinopoisk API quota exhaustion

### DIFF
--- a/src/KinopoiskUnofficialInfo.ApiClient.Tests/ApiQuotaTests.cs
+++ b/src/KinopoiskUnofficialInfo.ApiClient.Tests/ApiQuotaTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace KinopoiskUnofficialInfo.ApiClient.Tests
+{
+    public class ApiQuotaTests
+    {
+        [Fact]
+        public async Task ShouldNotSendAnotherRequestAfterQuotaExceeded()
+        {
+            var handler = new QuotaExceededHandler();
+            var httpClientFactory = new Mock<IHttpClientFactory>();
+
+            httpClientFactory
+                .Setup(factory => factory.CreateClient(It.IsAny<string>()))
+                .Returns(new HttpClient(handler));
+
+            using var cache = new MemoryCache(new MemoryCacheOptions());
+
+            var innerClient = new KinopoiskApiClient(
+                "test-token",
+                NullLogger<KinopoiskApiClient>.Instance,
+                httpClientFactory.Object);
+
+            var client = new CachedKinopoiskApiClient(
+                innerClient,
+                cache,
+                NullLogger<CachedKinopoiskApiClient>.Instance);
+
+            var firstResult = await client.GetSingleFilm(1);
+            var secondResult = await client.GetSingleFilm(2);
+
+            Assert.Null(firstResult);
+            Assert.Null(secondResult);
+            Assert.Equal(1, handler.RequestCount);
+        }
+
+        private sealed class QuotaExceededHandler : HttpMessageHandler
+        {
+            private int _requestCount;
+
+            public int RequestCount => _requestCount;
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                Interlocked.Increment(ref _requestCount);
+
+                return Task.FromResult(new HttpResponseMessage(
+                    (HttpStatusCode)402)
+                {
+                    Content = new StringContent(
+                        "{\"message\":\"Daily request limit exceeded\"}")
+                });
+            }
+        }
+    }
+}

--- a/src/KinopoiskUnofficialInfo.ApiClient.Tests/KinopoiskUnofficialInfo.ApiClient.Tests.csproj
+++ b/src/KinopoiskUnofficialInfo.ApiClient.Tests/KinopoiskUnofficialInfo.ApiClient.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/src/KinopoiskUnofficialInfo.ApiClient/CachedApiClient.cs
+++ b/src/KinopoiskUnofficialInfo.ApiClient/CachedApiClient.cs
@@ -28,19 +28,19 @@ namespace KinopoiskUnofficialInfo.ApiClient
         }
 
         public Task<PersonResponse> GetPerson(int personId, CancellationToken? cancellationToken = null)
-            => TryGetValue(GenerateKey(nameof(GetPerson), personId), c => c.GetPerson(personId, cancellationToken));
+            => TryGetValue(GenerateKey(nameof(GetPerson), personId), c => c.GetPerson(personId, cancellationToken), () => null);
 
         public Task<Film> GetSingleFilm(int filmId, CancellationToken? cancellationToken = null)
-            => TryGetValue(GenerateKey(nameof(GetSingleFilm), filmId), c => c.GetSingleFilm(filmId, cancellationToken));
+            => TryGetValue(GenerateKey(nameof(GetSingleFilm), filmId), c => c.GetSingleFilm(filmId, cancellationToken), () => null);
 
         public Task<ICollection<StaffResponse>> GetStaff(int filmId, CancellationToken? cancellationToken = null)
-            => TryGetValue(GenerateKey(nameof(GetStaff), filmId), c => c.GetStaff(filmId, cancellationToken));
+            => TryGetValue(GenerateKey(nameof(GetStaff), filmId), c => c.GetStaff(filmId, cancellationToken), () => Array.Empty<StaffResponse>());
 
         public Task<VideoResponse> GetTrailers(int filmId, CancellationToken? cancellationToken = null)
-            => TryGetValue(GenerateKey(nameof(GetTrailers), filmId), c => c.GetTrailers(filmId, cancellationToken));
+            => TryGetValue(GenerateKey(nameof(GetTrailers), filmId), c => c.GetTrailers(filmId, cancellationToken), () => new VideoResponse());
 
         public Task<FilmSearchResponse> SearchByKeyword(string keyword, int page = 1, CancellationToken? cancellationToken = null)
-            => TryGetValue(GenerateKey(nameof(SearchByKeyword), keyword, page), c => c.SearchByKeyword(keyword, page, cancellationToken));
+            => TryGetValue(GenerateKey(nameof(SearchByKeyword), keyword, page), c => c.SearchByKeyword(keyword, page, cancellationToken), () => new FilmSearchResponse());
 
         private static string GenerateKey(params object[] objects)
         {
@@ -71,16 +71,25 @@ namespace KinopoiskUnofficialInfo.ApiClient
             return key;
         }
 
-        private Task<T> TryGetValue<T>(string key, Func<IKinopoiskApiClient, Task<T>> resultFactory)
+        private Task<T> TryGetValue<T>(
+            string key,
+            Func<IKinopoiskApiClient, Task<T>> resultFactory,
+            Func<T> quotaFallbackFactory)
         {
             return _cache.GetOrCreateAsync(key, async entry =>
             {
                 _logger.LogDebug($"Entry '{key}' not found in cache, requesting from server");
                 entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(1);
 
-                var result = await resultFactory.Invoke(_innerClient).ConfigureAwait(false);
-
-                return result;
+                try
+                {
+                    return await resultFactory.Invoke(_innerClient).ConfigureAwait(false);
+                }
+                catch (ApiException exception) when (exception.StatusCode == 402)
+                {
+                    _logger.LogDebug($"Kinopoisk API quota exceeded; caching empty result for '{key}'");
+                    return quotaFallbackFactory();
+                }
             });
         }
     }

--- a/src/KinopoiskUnofficialInfo.ApiClient/KinopoiskApiClient.cs
+++ b/src/KinopoiskUnofficialInfo.ApiClient/KinopoiskApiClient.cs
@@ -15,6 +15,12 @@ namespace KinopoiskUnofficialInfo.ApiClient
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly Client _apiClient;
 
+        private static readonly TimeSpan QuotaCooldown = TimeSpan.FromHours(1);
+
+        private readonly object _quotaLock = new object();
+        private DateTimeOffset _quotaBlockedUntil = DateTimeOffset.MinValue;
+        private string _quotaExceededResponse = string.Empty;
+
         public KinopoiskApiClient(string apiToken, ILogger<KinopoiskApiClient> logger, IHttpClientFactory httpClientFactory)
         {
             if (string.IsNullOrEmpty(apiToken))
@@ -31,18 +37,78 @@ namespace KinopoiskUnofficialInfo.ApiClient
             _apiClient = new Client(httpClient);
         }
 
-        private async Task<T> Invoke<T>(Func<CancellationToken, Task<T>> method, CancellationToken? ct, [CallerMemberName] string memberName = "")
+        private async Task<T> Invoke<T>(
+            Func<CancellationToken, Task<T>> method,
+            CancellationToken? ct,
+            [CallerMemberName] string memberName = "")
         {
+            ApiException quotaException = null;
+
+            lock (_quotaLock)
+            {
+                if (DateTimeOffset.UtcNow < _quotaBlockedUntil)
+                {
+                    quotaException = new ApiException(
+                        "Kinopoisk API daily request limit exceeded.",
+                        402,
+                        _quotaExceededResponse,
+                        new Dictionary<string, IEnumerable<string>>(),
+                        null);
+                }
+            }
+
+            if (quotaException != null)
+            {
+                throw quotaException;
+            }
+
             try
             {
                 _logger.LogDebug($"{memberName} request starting...");
-                var res = await method.Invoke(ct ?? CancellationToken.None);
-                _logger.LogDebug($"{memberName} request complete successfully");
+
+                var res = await method.Invoke(
+                    ct ?? CancellationToken.None);
+
+                _logger.LogDebug(
+                    $"{memberName} request complete successfully");
+
                 return res;
             }
             catch (ApiException e)
             {
-                _logger.LogError($"Received non-success result status code {e.StatusCode} from Kinopoisk API, response content is:\n{e.Response}");
+                if (e.StatusCode == 402)
+                {
+                    var shouldLog = false;
+                    var blockedUntil = DateTimeOffset.MinValue;
+                    var now = DateTimeOffset.UtcNow;
+
+                    lock (_quotaLock)
+                    {
+                        if (now >= _quotaBlockedUntil)
+                        {
+                            _quotaBlockedUntil = now.Add(QuotaCooldown);
+                            _quotaExceededResponse = e.Response ?? string.Empty;
+
+                            blockedUntil = _quotaBlockedUntil;
+                            shouldLog = true;
+                        }
+                    }
+
+                    if (shouldLog)
+                    {
+                        _logger.LogWarning(
+                            $"Kinopoisk API daily request quota exceeded; " +
+                            $"requests are paused until {blockedUntil:u}");
+                    }
+                }
+                else
+                {
+                    _logger.LogError(
+                        $"Received non-success result status code " +
+                        $"{e.StatusCode} from Kinopoisk API, " +
+                        $"response content is:\n{e.Response}");
+                }
+
                 throw;
             }
         }


### PR DESCRIPTION
## Summary

Handle HTTP 402 responses returned when the Kinopoisk API daily request quota is exhausted.

- Pause outgoing API requests for one hour after the first HTTP 402 response
- Log the quota exhaustion once as a warning
- Return safe empty results from the cached client instead of propagating repeated exceptions
- Preserve the existing behavior for all other API errors
- Add a regression test verifying that no second HTTP request is sent after quota exhaustion

## Testing

- Added `ApiQuotaTests.ShouldNotSendAnotherRequestAfterQuotaExceeded`
- Full test suite passes: 13/13